### PR TITLE
Add `return` to try/catch blocks that end a function

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -811,6 +811,8 @@ function lastReturnStatement(nodeList = []) {
       return nodeList;
     } else if (nodeList[lastIndex].type === 'IfStatement') {
       nodeList[lastIndex] = addReturnStatementToIfBlocks(nodeList[lastIndex]);
+    } else if (nodeList[lastIndex].type === 'TryStatement') {
+      nodeList[lastIndex] = addReturnStatementsToTryCatch(nodeList[lastIndex]);
     } else {
       nodeList[lastIndex] =
         b.returnStatement(
@@ -842,11 +844,19 @@ function addReturnStatementToIfBlocks(node) {
 
 function addReturnStatementToBlock(node) {
   const hasReturnStatement = findIndex(node.body, {type: 'ReturnStatement'}) === node.body.length - 1;
-
-  if (hasReturnStatement) {
-    return node;
+  if (!hasReturnStatement) {
+    node.body = lastReturnStatement(node.body);
   }
-  node.body = lastReturnStatement(node.body);
+  return node;
+}
+
+
+function addReturnStatementsToTryCatch(node) {
+  node.block = addReturnStatementToBlock(node.block);
+  if (node.handler) {
+    node.handler.body = addReturnStatementToBlock(node.handler.body);
+  }
+
   return node;
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1793,6 +1793,44 @@ var x = (() => {
 })();`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('inserts try return statement when last function statement', () => {
+    const example =
+`x = () ->
+  try
+    foo()
+  finally
+    bar()`;
+
+    const expected =
+`var x = function() {
+  try {
+    return foo();
+  } finally {
+    bar();
+  }
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('inserts catch return statement when last function statement', () => {
+    const example =
+`x = () ->
+  try
+    foo()
+  catch e
+    bar()`;
+
+    const expected =
+`var x = function() {
+  try {
+    return foo();
+  } catch (e) {
+    return bar();
+  }
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('switch blocks', () => {


### PR DESCRIPTION
This also removes the IIFE wrapper around function-ending try/catches.  I'm 99% sure those IIFEs aren't necessary, but let me know if I'm missing something.