### PR TITLE
Fix slices by cheating with recast

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -107,12 +107,8 @@ function mapRange(node, meta) {
 }
 
 function mapSlice(node, meta) {
-  const {range} = node;
-  const args = [range.from ? mapExpression(range.from, meta) : b.literal(0)];
-  if (range.to) {
-    args.push(mapExpression(range.to, meta));
-  }
-  return b.callExpression(b.identifier('slice'), args);
+  const jsString = node.compile(meta).substring(1);
+  return recast.parse(jsString).program.body[0].expression;
 }
 
 function mapValue(node, meta) {

--- a/test/test.js
+++ b/test/test.js
@@ -2374,19 +2374,19 @@ describe('slices', () => {
 
   it('bam[1..10]', () => {
     const example = `bam[1..10]`;
-    const expected = `bam.slice(1, 10);`;
+    const expected = `bam.slice(1, 11);`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('bam[1..10.5]', () => {
     const example = `bam[1..10.5]`;
-    const expected = `bam.slice(1, 10.5);`;
+    const expected = `bam.slice(1, +10.5 + 1 || 9e9);`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('bam[a()..b()]', () => {
     const example = `bam[a()..b()]`;
-    const expected = `bam.slice(a(), b());`;
+    const expected = `bam.slice(a(), +b() + 1 || 9e9);`;
     expect(compile(example)).toEqual(expected);
   });
 
@@ -2398,13 +2398,31 @@ describe('slices', () => {
 
   it('bam[..1]', () => {
     const example = `bam[..1]`;
-    const expected = `bam.slice(0, 1);`;
+    const expected = `bam.slice(0, 2);`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('bam[..]', () => {
     const example = `bam[..]`;
     const expected = `bam.slice(0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[foo..-1]', () => {
+    const example = `bam[foo..-1]`;
+    const expected = `bam.slice(foo);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[foo..-2]', () => {
+    const example = `bam[foo..-2]`;
+    const expected = `bam.slice(foo, -1);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[-2..]', () => {
+    const example = `bam[-2..]`;
+    const expected = `bam.slice(-2);`;
     expect(compile(example)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Fixes:
- Off-by-1 errors for inclusive ranges
- Ensure ranges ending with a var never evaluate to 0

I started out by trying to fix this without leaning on `recast`, but the code gets ugly once you have to consider different node types for positive/negative end bounds.  I gave up and used `recast` once the variable-end-bound-should-never-be-0 thing cropped up :/