### PR TITLE
Don't silently drop assignments from for loops with guards

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2264,6 +2264,22 @@ for (var value of values) {
 }`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('assigns conditional loop result using array filter', () => {
+    const example = 'results = (item for item in items when item.code[0..1] == expected)';
+    const expected =
+`var results = (items.filter(item => item.code.slice(0, 2) === expected));`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('transform-and-assigns conditional loop result using array filter-and-map', () => {
+    const example = 'results = (item.name for item in items when item == expected)';
+    const expected =
+`var results = (items.filter(item => item === expected).map(item => {
+  return item.name;
+}));`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('ranges', () => {


### PR DESCRIPTION
Takes Coffee like:
```
results = (item.name for item in items when item == expected)
```

And turns it into
```
results = items.filter(item => item === expected).map(item => return item.name);
```

Suppresses the `map` call if no transform is necessary.