### PR TITLE
Hoist class-private vars above the class; move static class calls to …

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
   "env": {
     "browser": true,
     "jest": true,
-    "jasmine": true,
+    "mocha": true,
     "commonjs": true
   },
   "rules": {


### PR DESCRIPTION
…below the class.

This works for Shopify's codebase because we have one class per file, and don't do anything weird with private-static calls.  If it'd help to get this PR accepted, I can add a command line flag to enable/disable this behaviour.